### PR TITLE
fix: scope send-buffer growth to static file streaming

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1931,6 +1931,9 @@ static void static_cb(struct mg_connection *c, int ev, void *ev_data) {
     size_t n, max = MG_IO_SIZE, space;
     size_t *cl = (size_t *) &c->data[(sizeof(c->data) - sizeof(size_t)) /
                                      sizeof(size_t) * sizeof(size_t)];
+    // Use a wider send window for large static files without inflating
+    // formatter-backed keep-alive buffers for tiny replies.
+    if (*cl > 4096 && max < 4096) max = 4096;
     if (c->send.size < max) mg_iobuf_resize(&c->send, max);
     if (c->send.len >= c->send.size) return;  // Rate limit
     if ((space = c->send.size - c->send.len) > *cl) space = *cl;
@@ -7734,7 +7737,10 @@ size_t mg_queue_printf(struct mg_queue *q, const char *fmt, ...) {
 
 static void mg_pfn_iobuf_private(char ch, void *param, bool expand) {
   struct mg_iobuf *io = (struct mg_iobuf *) param;
-  if (expand && io->len + 2 > io->size) mg_iobuf_resize(io, io->len + 2);
+  // Grow geometrically, but do not impose a large minimum for small
+  // formatted writes because connection send buffers retain their capacity.
+  if (expand && io->len + 2 > io->size)
+    mg_iobuf_resize(io, io->size > 0 ? io->size * 2 : io->len + 2);
   if (io->len + 2 <= io->size) {
     io->buf[io->len++] = (uint8_t) ch;
     io->buf[io->len] = 0;


### PR DESCRIPTION
## Summary

This keeps the large static-file improvement, but avoids turning it into a formatter-wide memory policy.

- restore geometric growth in `mg_pfn_iobuf_private()` without a hard 4 KB minimum
- widen the send buffer to 4 KB only in `static_cb()` when serving a static file with more than 4 KB left to stream
- document the reason in code comments so the distinction stays visible in future reviews

## Why this change is needed

The earlier 4 KB minimum was added in the generic formatter-backed iobuf sink. That helped the `mg_http_serve_file()` case indirectly, because the response headers are written with `mg_printf()` and the larger `c->send` buffer is then reused by the static file streaming loop.

The problem is that the same sink is also used by small formatted writes such as `mg_printf()`, `mg_http_reply()`, and `mg_vmprintf()`. On builds where buffer alignment is smaller than 4 KB, the first tiny formatted write now allocates at least 4 KB.

For connection send buffers, that is not a temporary cost. `c->send` retains its capacity after draining, so a tiny keep-alive response can permanently inflate per-connection memory. With defaults like `MG_IO_SIZE = 512`, that is a meaningful regression for memory-constrained or high-concurrency deployments.

## Why scope the fix to `static_cb()`

Large static files and tiny formatted replies have different requirements:

- large static assets benefit from a wider send window to reduce repeated small reads/appends
- tiny formatted replies should stay cheap, because they are common and the buffer capacity is retained for the lifetime of the connection

By applying the 4 KB minimum only inside `static_cb()`, the optimization only affects the static-file body streaming path that actually benefits from it. The generic formatter still grows geometrically, so large formatted payloads do not regress to O(n^2), but small formatted writes no longer jump straight to 4 KB.

## Validation

- `moon info`
- `moon fmt`
- `moon test` (`301` passed, `0` failed)

No generated interface files changed.
