### PR TITLE
[codex] fix warnings across targets

### DIFF
--- a/cookie.mbt
+++ b/cookie.mbt
@@ -69,7 +69,7 @@ pub fn parse_cookie(cookie : StringView) -> Map[String, CookieItem] {
         "(?i:max-age)" =>
           {
             ..item,
-            max_age: try @strconv.parse_int(value) catch {
+            max_age: try @string.parse_int(value) catch {
               _ => None
             } noraise {
               x => Some(x)

--- a/examples/responder/pkg.generated.mbti
+++ b/examples/responder/pkg.generated.mbti
@@ -10,9 +10,7 @@ import {
 // Errors
 
 // Types and methods
-type Person
-pub impl ToJson for Person
-pub impl @json.FromJson for Person
+type Person derive(ToJson, @json.FromJson)
 
 // Type aliases
 

--- a/fetch.js.mbt
+++ b/fetch.js.mbt
@@ -54,7 +54,7 @@ pub async fn fetch(
   if req_body is Some(body_str) {
     options["body"] = body_str
   }
-  if not(req_headers.is_empty()) {
+  if !req_headers.is_empty() {
     let headers_obj = @js.Object::new()
     req_headers.each(fn(k, v) { headers_obj[k] = v })
     options["headers"] = headers_obj.to_value()

--- a/fetch.wasm.mbt
+++ b/fetch.wasm.mbt
@@ -9,11 +9,14 @@ pub async fn fetch(
   mode? : FetchMode,
 ) -> HttpResponse raise Error {
   ignore(url)
-  ignore(body)
   ignore(http_method)
-  ignore(data)
-  ignore(headers)
   ignore(credentials)
   ignore(mode)
-  raise FetchError::RequestFailed("fetch is not implemented on wasm target")
+  ignore(body)
+  ignore(data)
+  ignore(headers)
+  ignore(prepare_fetch_payload)
+  suspend(fn(_ok_cb, reject) {
+    reject(FetchError::RequestFailed("fetch is not implemented on wasm target"))
+  })
 }

--- a/js/async_test.mbt
+++ b/js/async_test.mbt
@@ -16,7 +16,7 @@ fn op3() -> String? noraise {
 
 ///|
 test "Promise::wait" {
-  @js.async_test(fn() raise {
+  @js.async_test(async fn() {
     // Promise::unsafe_new + Promise::wait is a noop.
     let res = @js.Promise::unsafe_new(() => op1()).wait()
     assert_eq(res.cast(), Some("Hello"))
@@ -25,7 +25,7 @@ test "Promise::wait" {
 
 ///|
 test "async_all" {
-  @js.async_test(fn() raise {
+  @js.async_test(async fn() {
     assert_eq(@js.async_all([() => op2(), () => op1(), () => op3()]), [
       Some("Hello, World"),
       Some("Hello"),

--- a/js/cast.mbt
+++ b/js/cast.mbt
@@ -85,7 +85,7 @@ pub impl[A : Cast] Cast for Array[A] with into(value) {
   checked_cast_array_ffi(value)
   .to_option()
   .bind(fn(arr) {
-    let is_type_a = fn(elem) { not((Cast::into(elem) : A?) is None) }
+    let is_type_a = fn(elem) { !((Cast::into(elem) : A?) is None) }
     if arr.iter().all(is_type_a) {
       Some(Value::cast_from(arr).cast())
     } else {

--- a/js/error.mbt
+++ b/js/error.mbt
@@ -10,7 +10,7 @@ extern "js" fn Error_::cause_ffi(self : Value) -> Value = "(self) => self.cause"
 pub fn Error_::cause(self : Error_) -> Value? {
   let Error_(inner) = self
   let cause = Error_::cause_ffi(inner)
-  guard not(cause.is_undefined()) else { None }
+  guard !cause.is_undefined() else { None }
   Some(cause.cast())
 }
 

--- a/js/null.mbt
+++ b/js/null.mbt
@@ -21,7 +21,7 @@ pub fn[T] Nullable::unwrap(self : Nullable[T]) -> T {
 
 ///|
 pub fn[T] Nullable::to_option(self : Nullable[T]) -> T? {
-  guard not(Value::cast_from(self).is_null()) else { None }
+  guard !Value::cast_from(self).is_null() else { None }
   Some(self.get_exn())
 }
 

--- a/js/value_test.mbt
+++ b/js/value_test.mbt
@@ -60,12 +60,14 @@ let json_str_pretty =
   #|}
 
 ///|
-let json_val : @js.Value = (try? @js.Value::from_json_string(json_str_pretty)).unwrap()
+fn json_val() -> @js.Value {
+  try! @js.Value::from_json_string(json_str_pretty)
+}
 
 ///|
 test "Value::to_json_string" {
   inspect(
-    json_val.to_json_string(),
+    json_val().to_json_string(),
     content=(
       #|{"_id":"67a6c712bc218526d5e1b516","index":0,"guid":"74e69a18-680a-4a74-a401-e386c30d0a35","isActive":false,"balance":"$3,140.03","picture":"http://placehold.it/32x32","age":33,"eyeColor":"blue","name":"Burt Dominguez","gender":"male","company":"GEEKWAGON","email":"burtdominguez@geekwagon.com","phone":"+1 (913) 583-3488","address":"379 Essex Street, Fresno, Minnesota, 5304","about":"Proident velit ullamco cillum occaecat irure eu proident commodo consectetur est ut elit consectetur.","registered":"2020-12-06T01:54:20 -08:00","latitude":71.680916,"longitude":-88.552886,"tags":["aute","occaecat","qui","esse","commodo","sint","proident"],"friends":[{"id":0,"name":"Gilliam Mcgowan"},{"id":1,"name":"Bryan Stanton"},{"id":2,"name":"Jenifer Elliott"}],"greeting":"Hello, Burt Dominguez! You have 4 unread messages.","favoriteFruit":"apple"}
     ),
@@ -74,13 +76,13 @@ test "Value::to_json_string" {
 
 ///|
 test "Value::to_json" {
-  assert_eq(json_val.to_json(), json)
+  assert_eq(json_val().to_json(), json)
 }
 
 ///|
 test "Value::from_json" {
   assert_eq(
     @js.Value::from_json(json).to_json_string(),
-    json_val.to_json_string(),
+    json_val().to_json_string(),
   )
 }

--- a/mocket.js.mbt
+++ b/mocket.js.mbt
@@ -308,7 +308,7 @@ pub fn serve_ffi(mocket : Mocket, port~ : Int) -> Unit {
           let headers_obj = (try? @js.Value::from_json(
             event.res.headers.to_json(),
           )).or(@js.Object::new().to_value())
-          if not(event.res.cookies.is_empty()) {
+          if !event.res.cookies.is_empty() {
             let cookies = event.res.cookies
               .values()
               .map(fn(c) { c.to_string() })
@@ -358,7 +358,7 @@ extern "js" fn _init_bindings_map() -> @js.Value = "() => { if (!globalThis.ws_p
 pub fn register_ws_handler(mocket : Mocket, port : Int) -> Unit {
   let mut done = false
   mocket.ws_static_routes.each(fn(_, handler) {
-    if not(done) {
+    if !done {
       ws_handler_map.set(port, handler)
       ws_mocket_map.set(port, mocket)
       ignore(_init_bindings_map())

--- a/mocket.native.mbt
+++ b/mocket.native.mbt
@@ -104,7 +104,7 @@ let ws_handler_map : Map[Int, WebSocketHandler] = Map::new()
 pub fn register_ws_handler(mocket : Mocket, port : Int) -> Unit {
   let mut done = false
   mocket.ws_static_routes.each(fn(_, handler) {
-    if not(done) {
+    if !done {
       ws_handler_map.set(port, handler)
       done = true
     }

--- a/mocket.wasm.mbt
+++ b/mocket.wasm.mbt
@@ -1,5 +1,67 @@
 ///|
+fn wasm_websocket_peer() -> WebSocketPeer {
+  WebSocketPeer::{ connection_id: "", subscribed_channels: [] }
+}
+
+///|
+fn keep_websocket_symbols_alive() -> Unit {
+  ignore(WebSocketEvent::Open(wasm_websocket_peer()))
+  ignore(
+    WebSocketEvent::Message(
+      wasm_websocket_peer(),
+      WebSocketAggregatedMessage::Text(""),
+    ),
+  )
+  ignore(WebSocketEvent::Close(wasm_websocket_peer()))
+  ignore(WebSocketAggregatedMessage::Binary(b""))
+  ignore(WebSocketAggregatedMessage::Ping)
+}
+
+///|
 pub fn serve_ffi(mocket : Mocket, port~ : Int) -> Unit {
-  // Unimplemented
+  ignore(mocket.find_route("GET", "/"))
+  ignore(port)
+  keep_websocket_symbols_alive()
+  panic()
+}
+
+///|
+pub fn ws_send(id : String, msg : String) -> Unit {
+  ignore(id)
+  ignore(msg)
+  panic()
+}
+
+///|
+pub fn ws_send_bytes(id : String, msg : Bytes) -> Unit {
+  ignore(id)
+  ignore(msg)
+  panic()
+}
+
+///|
+pub fn ws_pong(id : String) -> Unit {
+  ignore(id)
+  panic()
+}
+
+///|
+pub fn ws_subscribe(id : String, channel : String) -> Unit {
+  ignore(id)
+  ignore(channel)
+  panic()
+}
+
+///|
+pub fn ws_unsubscribe(id : String, channel : String) -> Unit {
+  ignore(id)
+  ignore(channel)
+  panic()
+}
+
+///|
+pub fn ws_publish(channel : String, msg : String) -> Unit {
+  ignore(channel)
+  ignore(msg)
   panic()
 }

--- a/moon.pkg
+++ b/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbitlang/x/codec/base64",
   "moonbitlang/core/json",
   "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "moonbitlang/core/buffer",
   "moonbitlang/core/encoding/utf8",
 }

--- a/path_match.mbt
+++ b/path_match.mbt
@@ -2,7 +2,7 @@
 // 匹配路径并提取参数 - 重写版本，消除复杂性
 fn match_path(template : String, path : String) -> Map[String, StringView]? {
   // 静态路径直接比较 - 好品味：消除特殊情况
-  if not(template.contains(":")) && not(template.contains("*")) {
+  if !template.contains(":") && !template.contains("*") {
     return if template == path { Some({}) } else { None }
   }
 

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -56,19 +56,15 @@ pub fn ws_subscribe(String, String) -> Unit
 pub fn ws_unsubscribe(String, String) -> Unit
 
 // Errors
-pub suberror ExecError
-pub impl Show for ExecError
+pub suberror ExecError derive(Show)
 
 pub suberror FetchError {
   RequestFailed(String)
-}
-pub impl Show for FetchError
+} derive(Show)
 
-pub suberror IOError
-pub impl Show for IOError
+pub suberror IOError derive(Show)
 
-pub suberror NetworkError
-pub impl Show for NetworkError
+pub suberror NetworkError derive(Show)
 
 // Types and methods
 pub(all) struct CookieItem {
@@ -80,28 +76,23 @@ pub(all) struct CookieItem {
   secure : Bool?
   http_only : Bool?
   same_site : SameSiteOption?
-}
-pub impl Eq for CookieItem
+} derive(Eq)
 pub impl Show for CookieItem
 
 pub(all) enum FetchCredentials {
   Omit
   SameOrigin
   Include
-}
+} derive(Eq, Show)
 pub fn FetchCredentials::to_string(Self) -> String
-pub impl Eq for FetchCredentials
-pub impl Show for FetchCredentials
 
 pub(all) enum FetchMode {
   Cors
   NoCors
   SameOrigin
   Navigate
-}
+} derive(Eq, Show)
 pub fn FetchMode::to_string(Self) -> String
-pub impl Eq for FetchMode
-pub impl Show for FetchMode
 
 type Html
 pub impl Responder for Html
@@ -116,9 +107,7 @@ pub(all) enum HttpMethod {
   OPTIONS
   TRACE
   CONNECT
-}
-pub impl Eq for HttpMethod
-pub impl Show for HttpMethod
+} derive(Eq, Show)
 
 pub(all) struct HttpRequest {
   http_method : String
@@ -202,9 +191,7 @@ pub(all) enum SameSiteOption {
   Lax
   Strict
   SameSiteNone
-}
-pub impl Eq for SameSiteOption
-pub impl Show for SameSiteOption
+} derive(Eq, Show)
 pub impl ToJson for SameSiteOption
 
 pub(all) struct StaticAssetMeta {
@@ -281,12 +268,9 @@ pub(all) enum StatusCode {
   NotExtended
   NetworkAuthenticationRequired
   Custom(Int)
-}
+} derive(Eq, Show, ToJson)
 pub fn StatusCode::from_int(Int) -> Self
 pub fn StatusCode::to_int(Self) -> Int
-pub impl Eq for StatusCode
-pub impl Show for StatusCode
-pub impl ToJson for StatusCode
 
 pub enum WebSocketAggregatedMessage {
   Text(String)

--- a/static.mbt
+++ b/static.mbt
@@ -43,7 +43,7 @@ pub fn Mocket::static_assets(
   provider : &ServeStaticProvider,
 ) -> Unit {
   self.use_middleware(async fn(event, next) noraise {
-    if not(match_path(path, event.req.url) is None) {
+    if !(match_path(path, event.req.url) is None) {
       return next()
     }
 
@@ -126,7 +126,7 @@ pub fn Mocket::static_assets(
         }
         match meta.etag {
           Some(etag) => {
-            if not(event.res.headers.contains("ETag")) {
+            if !event.res.headers.contains("ETag") {
               event.res.headers.set("ETag", etag)
             }
             if event.req.headers.get("If-None-Match") == Some(etag) {
@@ -137,7 +137,7 @@ pub fn Mocket::static_assets(
         }
 
         // Content-Type
-        if not(event.res.headers.contains("Content-Type")) {
+        if !event.res.headers.contains("Content-Type") {
           match meta.asset_type {
             Some(t) => event.res.headers.set("Content-Type", t)
             None => {
@@ -156,7 +156,7 @@ pub fn Mocket::static_assets(
         // Content-Encoding
         match meta.encoding {
           Some(enc) =>
-            if not(event.res.headers.contains("Content-Encoding")) {
+            if !event.res.headers.contains("Content-Encoding") {
               event.res.headers.set("Content-Encoding", enc)
             }
           None => ()
@@ -165,7 +165,7 @@ pub fn Mocket::static_assets(
         // Content-Length
         match meta.size {
           Some(size) =>
-            if size > 0L && not(event.res.headers.contains("Content-Length")) {
+            if size > 0L && !event.res.headers.contains("Content-Length") {
               event.res.headers.set("Content-Length", size.to_string())
             }
           None => ()

--- a/uri/pkg.generated.mbti
+++ b/uri/pkg.generated.mbti
@@ -20,16 +20,12 @@ pub struct Authority {
   mut userinfo : BytesView?
   mut host : Host
   mut port : Int?
-}
-pub impl Eq for Authority
-pub impl Show for Authority
+} derive(Eq, Show)
 
 pub enum Host {
   IPv6Address(BytesView)
   RegName(BytesView)
-}
-pub impl Eq for Host
-pub impl Show for Host
+} derive(Eq, Show)
 
 pub struct Uri {
   mut scheme : BytesView?
@@ -37,10 +33,8 @@ pub struct Uri {
   path : Array[BytesView]
   mut query : BytesView?
   mut fragment : BytesView?
-}
+} derive(Eq, Show)
 pub fn Uri::parse(BytesView) -> Self raise ParseError
-pub impl Eq for Uri
-pub impl Show for Uri
 
 // Type aliases
 

--- a/uri/uri.mbt
+++ b/uri/uri.mbt
@@ -113,28 +113,29 @@ fn parse_scheme_or_segment_nz_nc(
   source : BytesView,
   uri : Uri,
 ) -> BytesView raise ParseError {
-  let s = source
-  let segment = s
-  loop s {
-    [':', .. k] as s => {
-      uri.scheme = Some(source.slice_until(s))
-      parse_hier_part_then_query(k, uri)
+  let segment = source
+  for s = source {
+    match s {
+      [':', .. k] as s => {
+        uri.scheme = Some(source.slice_until(s))
+        return parse_hier_part_then_query(k, uri)
+      }
+      ['/', .. k] as s => {
+        uri.path.push(segment.slice_until(s))
+        return parse_path_abempty_then_query(k, uri)
+      }
+      ['?', .. k] as s => {
+        uri.path.push(segment.slice_until(s))
+        return parse_query_then_fragment(k, uri)
+      }
+      ['#', .. k] as s => {
+        uri.path.push(segment.slice_until(s))
+        return parse_query_then_fragment(k, uri)
+      }
+      [b, .. k] if is_unreserved_byte(b) || is_sub_delim_byte(b) || b == '@' =>
+        continue k
+      _ => raise ParseError::InvalidSchemeOrSegment(source)
     }
-    ['/', .. k] as s => {
-      uri.path.push(segment.slice_until(s))
-      parse_path_abempty_then_query(k, uri)
-    }
-    ['?', .. k] as s => {
-      uri.path.push(segment.slice_until(s))
-      parse_query_then_fragment(k, uri)
-    }
-    ['#', .. k] as s => {
-      uri.path.push(segment.slice_until(s))
-      parse_query_then_fragment(k, uri)
-    }
-    [b, .. k] if is_unreserved_byte(b) || is_sub_delim_byte(b) || b == '@' =>
-      continue k
-    _ => raise ParseError::InvalidSchemeOrSegment(source)
   }
 }
 
@@ -182,18 +183,20 @@ pub fn Uri::parse(source : BytesView) -> Uri raise ParseError {
 fn parse_scheme(source : BytesView, uri : Uri) -> BytesView raise ParseError {
   match source {
     [b, .. k] if is_alpha_byte(b) =>
-      loop k {
-        [b, .. s] if is_alpha_byte(b) ||
-          is_digit_byte(b) ||
-          b == '+' ||
-          b == '-' ||
-          b == '.' => continue s
-        [':', .. k] as s => {
-          uri.scheme = Some(source.slice_until(s))
-          return k
+      for s = k {
+        match s {
+          [b, .. s] if is_alpha_byte(b) ||
+            is_digit_byte(b) ||
+            b == '+' ||
+            b == '-' ||
+            b == '.' => continue s
+          [':', .. k] as s => {
+            uri.scheme = Some(source.slice_until(s))
+            return k
+          }
+          [_, ..] as s => raise ParseError::InvalidScheme(s)
+          [] => raise ParseError::MissingColon
         }
-        [_, ..] as s => raise ParseError::InvalidScheme(s)
-        [] => raise ParseError::MissingColon
       }
     [_, ..] as s => raise ParseError::InvalidScheme(s)
     [] => raise ParseError::MissingScheme
@@ -222,16 +225,18 @@ fn parse_userinfo(
   authority : Authority,
 ) -> BytesView raise ParseError {
   let start = source
-  loop source {
-    ['@', .. k] as s => {
-      authority.userinfo = Some(start.slice_until(s))
-      return k
+  for s = source {
+    match s {
+      ['@', .. k] as s => {
+        authority.userinfo = Some(start.slice_until(s))
+        return k
+      }
+      ['%', .. k] => continue parse_percent_encoding(k)
+      [b, .. k] if is_unreserved_byte(b) || is_sub_delim_byte(b) || b == ':' =>
+        continue k
+      [_, ..] as s => raise ParseError::InvalidHeirPart(s)
+      [] as s => return s
     }
-    ['%', .. k] => continue parse_percent_encoding(k)
-    [b, .. k] if is_unreserved_byte(b) || is_sub_delim_byte(b) || b == ':' =>
-      continue k
-    [_, ..] as s => raise ParseError::InvalidHeirPart(s)
-    [] as s => return s
   }
 }
 
@@ -240,13 +245,14 @@ fn parse_reg_name(
   source : BytesView,
   authority : Authority,
 ) -> BytesView raise ParseError {
-  let s = source
-  loop s {
-    ['%', ..] as s => continue parse_percent_encoding(s)
-    [b, .. k] if is_unreserved_byte(b) || is_sub_delim_byte(b) => continue k
-    _ as s => {
-      authority.host = Host::RegName(source.slice_until(s))
-      s
+  for s = source {
+    match s {
+      ['%', ..] as s => continue parse_percent_encoding(s)
+      [b, .. k] if is_unreserved_byte(b) || is_sub_delim_byte(b) => continue k
+      _ as s => {
+        authority.host = Host::RegName(source.slice_until(s))
+        return s
+      }
     }
   }
 }
@@ -257,14 +263,15 @@ fn parse_ipv6_address(
   authority : Authority,
 ) -> BytesView raise ParseError {
   // Simplified IPv6 parsing - match until ']'
-  let s = source
-  loop s {
-    [']', .. k] as s => {
-      authority.host = IPv6Address(source.slice_until(s))
-      k
+  for s = source {
+    match s {
+      [']', .. k] as s => {
+        authority.host = IPv6Address(source.slice_until(s))
+        return k
+      }
+      [b, .. s] if is_hexdig_byte(b) || b == ':' || b == '.' => continue s
+      _ as s => raise ParseError::InvalidHeirPart(s)
     }
-    [b, .. s] if is_hexdig_byte(b) || b == ':' || b == '.' => continue s
-    _ as s => raise ParseError::InvalidHeirPart(s)
   }
 }
 
@@ -287,14 +294,16 @@ fn parse_port(source : BytesView, authority : Authority) -> BytesView {
   match source {
     [':', .. k] => {
       let mut port_val = 0
-      loop k {
-        [d, .. s] if is_digit_byte(d) => {
-          port_val = port_val * 10 + (d.to_int() - '0')
-          continue s
-        }
-        _ as s => {
-          authority.port = Some(port_val)
-          return s
+      for s = k {
+        match s {
+          [d, .. s] if is_digit_byte(d) => {
+            port_val = port_val * 10 + (d.to_int() - '0')
+            continue s
+          }
+          _ as s => {
+            authority.port = Some(port_val)
+            return s
+          }
         }
       }
     }
@@ -318,10 +327,12 @@ fn parse_authority(source : BytesView, uri : Uri) -> BytesView raise ParseError 
 ///|
 fn parse_segment(source : BytesView) -> (BytesView, BytesView) raise ParseError {
   let start = source
-  loop source {
-    ['%', .. k] => continue parse_percent_encoding(k)
-    [b, .. k] if is_pchar_byte(b) => continue k
-    _ as s => (s, start.slice_until(s))
+  for s = source {
+    match s {
+      ['%', .. k] => continue parse_percent_encoding(k)
+      [b, .. k] if is_pchar_byte(b) => continue k
+      _ as s => return (s, start.slice_until(s))
+    }
   }
 }
 
@@ -333,13 +344,14 @@ fn parse_done(source : BytesView, _uri : Uri) -> BytesView {
 
 ///|
 fn parse_fragment(source : BytesView, uri : Uri) -> BytesView raise ParseError {
-  let s = source
-  loop s {
-    ['%', ..] as s => continue parse_percent_encoding(s)
-    [b, .. k] if is_pchar_byte(b) || b == '/' || b == '?' => continue k
-    [..] as s => {
-      uri.fragment = Some(source.slice_until(s))
-      return s
+  for s = source {
+    match s {
+      ['%', ..] as s => continue parse_percent_encoding(s)
+      [b, .. k] if is_pchar_byte(b) || b == '/' || b == '?' => continue k
+      [..] as s => {
+        uri.fragment = Some(source.slice_until(s))
+        return s
+      }
     }
   }
 }
@@ -350,16 +362,18 @@ fn parse_query_then_fragment(
   uri : Uri,
 ) -> BytesView raise ParseError {
   let start = source
-  loop source {
-    ['#', .. k] as s => {
-      uri.query = Some(start.slice_until(s))
-      parse_fragment(k, uri)
-    }
-    ['%', ..] as s => continue parse_percent_encoding(s)
-    [b, .. k] if is_pchar_byte(b) || b == '/' || b == '?' => continue k
-    [..] as s => {
-      uri.query = Some(start.slice_until(s))
-      s
+  for s = source {
+    match s {
+      ['#', .. k] as s => {
+        uri.query = Some(start.slice_until(s))
+        return parse_fragment(k, uri)
+      }
+      ['%', ..] as s => continue parse_percent_encoding(s)
+      [b, .. k] if is_pchar_byte(b) || b == '/' || b == '?' => continue k
+      [..] as s => {
+        uri.query = Some(start.slice_until(s))
+        return s
+      }
     }
   }
 }
@@ -369,39 +383,40 @@ fn parse_path_abempty_then_query(
   source : BytesView,
   uri : Uri,
 ) -> BytesView raise ParseError {
-  let s = source
-  loop s {
-    ['%', .. k] => continue parse_percent_encoding(k)
-    ['/', .. k] as s => {
-      let segment = source.slice_until(s)
-      if segment != "" {
-        uri.path.push(segment)
+  for s = source {
+    match s {
+      ['%', .. k] => continue parse_percent_encoding(k)
+      ['/', .. k] as s => {
+        let segment = source.slice_until(s)
+        if segment != "" {
+          uri.path.push(segment)
+        }
+        return parse_path_abempty_then_query(k, uri)
       }
-      parse_path_abempty_then_query(k, uri)
-    }
-    ['?', .. k] as s => {
-      let segment = source.slice_until(s)
-      if segment != "" {
-        uri.path.push(segment)
+      ['?', .. k] as s => {
+        let segment = source.slice_until(s)
+        if segment != "" {
+          uri.path.push(segment)
+        }
+        return parse_query_then_fragment(k, uri)
       }
-      parse_query_then_fragment(k, uri)
-    }
-    ['#', .. k] as s => {
-      let segment = source.slice_until(s)
-      if segment != "" {
-        uri.path.push(segment)
+      ['#', .. k] as s => {
+        let segment = source.slice_until(s)
+        if segment != "" {
+          uri.path.push(segment)
+        }
+        return parse_fragment(k, uri)
       }
-      parse_fragment(k, uri)
-    }
-    [b, .. k] if is_pchar_byte(b) => continue k
-    [] as s => {
-      let segment = source.slice_until(s)
-      if segment != "" {
-        uri.path.push(segment)
+      [b, .. k] if is_pchar_byte(b) => continue k
+      [] as s => {
+        let segment = source.slice_until(s)
+        if segment != "" {
+          uri.path.push(segment)
+        }
+        return s
       }
-      s
+      [..] as s => raise ParseError::InvalidSegment(s)
     }
-    [..] as s => raise ParseError::InvalidSegment(s)
   }
 }
 
@@ -451,16 +466,17 @@ fn parse_path_abempty_then_query_no_fragment(
   source : BytesView,
   uri : Uri,
 ) -> BytesView raise ParseError {
-  let s = source
-  loop s {
-    ['/', .. k] => {
-      let (remaining, segment_val) = parse_segment(k)
-      if segment_val != "" {
-        uri.path.push(segment_val)
+  for s = source {
+    match s {
+      ['/', .. k] => {
+        let (remaining, segment_val) = parse_segment(k)
+        if segment_val != "" {
+          uri.path.push(segment_val)
+        }
+        continue remaining
       }
-      continue remaining
+      _ as s => return parse_query_no_fragment_or_done(s, uri)
     }
-    _ as s => parse_query_no_fragment_or_done(s, uri)
   }
 }
 
@@ -481,12 +497,14 @@ fn parse_query_no_fragment_then_done(
   uri : Uri,
 ) -> BytesView raise ParseError {
   let start = source
-  loop source {
-    ['%', .. k] => continue parse_percent_encoding(k)
-    [b, .. k] if is_pchar_byte(b) || b == '/' || b == '?' => continue k
-    _ as s => {
-      uri.query = Some(start.slice_until(s))
-      parse_done(s, uri)
+  for s = source {
+    match s {
+      ['%', .. k] => continue parse_percent_encoding(k)
+      [b, .. k] if is_pchar_byte(b) || b == '/' || b == '?' => continue k
+      _ as s => {
+        uri.query = Some(start.slice_until(s))
+        return parse_done(s, uri)
+      }
     }
   }
 }

--- a/utils.mbt
+++ b/utils.mbt
@@ -145,7 +145,7 @@ pub fn form_encode(map : Map[String, String]) -> String {
   let buf = StringBuilder::new()
   let mut first = true
   map.each(fn(k, v) {
-    if not(first) {
+    if !first {
       buf.write_char('&')
     }
     first = false

--- a/websocket.mbt
+++ b/websocket.mbt
@@ -24,7 +24,7 @@ pub fn WebSocketPeer::pong(self : WebSocketPeer) -> Unit {
 
 ///|
 pub fn WebSocketPeer::subscribe(self : WebSocketPeer, channel : String) -> Unit {
-  if not(self.subscribed_channels.contains(channel)) {
+  if !self.subscribed_channels.contains(channel) {
     self.subscribed_channels.push(channel)
     ws_subscribe(self.connection_id, channel)
   }


### PR DESCRIPTION
## Summary

- remove deprecated syntax and lint warnings across native, js, and wasm codepaths
- add explicit wasm websocket stubs so all-target builds compile cleanly
- refresh generated `.mbti` files after `moon info`

## Why

- the module had deprecation warnings on the default target, and `moon check --target all` also exposed wasm-only warnings and missing symbols

## Impact

- `moon check --target all` is now clean
- unsupported wasm websocket/fetch paths now fail explicitly instead of relying on missing symbols
- no intended public API changes beyond regenerated interface output formatting

## Validation

- `moon check --target all`
- `moon test --target all`
- `moon info`
- `moon fmt`

## Review

- a fresh Codex review pass found no actionable findings after the wasm fetch follow-up fix
