### PR TITLE
fix: add escape_html utility and sanitize static file paths

### DIFF
--- a/static.mbt
+++ b/static.mbt
@@ -55,7 +55,17 @@ pub fn Mocket::static_assets(
       event.res.headers.set("Allow", "GET, HEAD")
       return HttpResponse::new(MethodNotAllowed)
     }
-    let original_id = event.req.url[path.length():].to_owned()
+    let raw_id = event.req.url[path.length():].to_owned()
+    let segments : Array[String] = []
+    for seg in raw_id.split("/") {
+      let s = seg.to_owned()
+      if s == ".." || s == "." || s == "" {
+        continue
+      } else {
+        segments.push(s)
+      }
+    }
+    let original_id = segments.join("/")
 
     // Parse Accept-Encoding
     // Headers are Map[StringView, StringView]

--- a/utils.mbt
+++ b/utils.mbt
@@ -101,6 +101,22 @@ fn parse_kv(part : BytesView, map : Map[String, String]) -> Unit {
 }
 
 ///|
+pub fn escape_html(s : String) -> String {
+  let buf = StringBuilder::new()
+  for c in s {
+    match c {
+      '&' => buf.write_string("&amp;")
+      '<' => buf.write_string("&lt;")
+      '>' => buf.write_string("&gt;")
+      '"' => buf.write_string("&quot;")
+      '\'' => buf.write_string("&#x27;")
+      _ => buf.write_char(c)
+    }
+  }
+  buf.to_string()
+}
+
+///|
 fn is_unreserved(b : Byte) -> Bool {
   (b >= b'A' && b <= b'Z') ||
   (b >= b'a' && b <= b'z') ||


### PR DESCRIPTION
## Summary

- **Reflected XSS (CWE-79, HIGH):** Add `escape_html()` utility function for sanitizing user input before HTML interpolation. Route parameters are currently embedded in HTML responses without encoding.
- **Path Traversal (CWE-22, HIGH):** Strip `..` and `.` segments from static file request paths before resolving against the document root, preventing reads of files outside the configured static directory.

## Vulnerability Details

### 1. Reflected XSS + Cookie Theft (CVSS 8.1)
The `html()` function in `responder.mbt` writes content directly to the response with `Content-Type: text/html` and no HTML encoding. When route parameters (e.g., `/hello/:name`) are interpolated via string templates, an attacker can inject arbitrary HTML/JavaScript. Combined with cookies lacking `HttpOnly`, this enables one-click session theft.

**Fix:** Add `escape_html()` to `utils.mbt` that encodes `& < > " '`. Framework users should call `escape_html()` on any user-supplied values before passing them to `html()`.

### 2. Static File Path Traversal (CVSS 7.5)
`static_assets()` in `static.mbt` extracts the file path from the URL and passes it directly to `StaticFileProvider.get_contents()` which concatenates it with the root directory. Requests like `GET /../../etc/passwd` can read arbitrary files on the server.

**Fix:** Split the path on `/`, filter out `..`, `.`, and empty segments, then rejoin — ensuring the resolved path never escapes the document root.

## Test plan

- [ ] Verify `escape_html("<script>alert(1)</script>")` returns `&lt;script&gt;alert(1)&lt;/script&gt;`
- [ ] Verify `GET /static/../../etc/passwd` returns 404 (not file contents)
- [ ] Verify normal static file serving still works (`GET /static/index.html`)
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)