### PR TITLE
fix: enable SO_REUSEADDR in native listener for rapid restarts

### DIFF
--- a/mocket.native.mbt
+++ b/mocket.native.mbt
@@ -478,6 +478,14 @@ async fn handle_websocket_request(
 }
 
 ///|
+/// Listen and serve on `address`.
+///
+/// The native listener enables `SO_REUSEADDR` (`reuse_addr=true`) so that a
+/// process can immediately rebind a port that a previous process left in
+/// `TIME_WAIT`. On macOS/BSD this has the side effect that a bind to a specific
+/// address may "steal" the specific interface from an existing wildcard bind
+/// (`0.0.0.0`), and a wildcard bind can bind to the remaining interfaces if a
+/// specific-interface bind already exists.
 pub async fn listen_ffi(mocket : Mocket, address : String) -> Unit noraise {
   let address = normalize_listen_address(address)
   let addr = @socket.Addr::parse(address) catch {
@@ -488,7 +496,7 @@ pub async fn listen_ffi(mocket : Mocket, address : String) -> Unit noraise {
   }
   let port = addr.port()
   register_ws_handler(mocket, port)
-  let server = @http.Server(addr) catch {
+  let server = @http.Server(addr, reuse_addr=true) catch {
     err => {
       println("mocket: failed to listen on \{address}: \{err}")
       return


### PR DESCRIPTION
## What

The native Mocket listener previously constructed `@http.Server(addr)` without `reuse_addr`, so `SO_REUSEADDR` was **disabled** (the pinned `moonbitlang/async@0.21.0` `TcpServer` defaults it to `false`). During rapid development restarts, a socket left in `TIME_WAIT` on the same `127.0.0.1:PORT` can make the new process report "Address already in use" even though no process is listening.

## Fix

Pass `reuse_addr=true` when building the native HTTP server:

```moonbit
let server = @http.Server(addr, reuse_addr=true) catch { ... }
```

This lets a fresh process immediately rebind a port a previous process just left in `TIME_WAIT`.

## Also

- Documented the `SO_REUSEADDR` behavior and the `moonbitlang/async` BSD/macOS side effect directly on `listen_ffi`: with reuse enabled, a bind to a specific address may "steal" the interface from an existing wildcard `0.0.0.0` bind, and a wildcard bind can bind to the remaining interfaces if a specific-interface bind already exists.

## Verification

- `moon check` is green on `native`, `js`, and `wasm`.
- Ran the `responder` example on `:4000`, sent traffic (`HTTP 200`), killed the process, and immediately relaunched — the second server successfully rebinds the same port.

## Note

The "propagate bind failures as checked errors" improvement is a separate, larger API-signature change (the public `Mocket::listen`/`serve` are `Unit noraise`); I scoped this PR to the primary fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)