### PR TITLE
chore: release v0.9.0

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "oboard/mocket"
 
-version = "0.8.0"
+version = "0.9.0"
 
 import {
   "moonbitlang/async@0.21.0",


### PR DESCRIPTION
## Summary

Version bump 0.8.0 → 0.9.0 after the static asset middleware rewrite (#29).

Minor (breaking for 0.x): `ServeStaticProvider::get_meta`/`get_contents` are now `async fn`, so third-party provider implementations need to adapt. `oboard/mocket/static_file` gained optional `fallthrough`/`index_names` parameters and now resolves MIME types via `oboard/mimetype@0.2.0`.

## Verification (on merged main, a982650)

- `moon check --deny-warn` clean; `moon info --target native` / `moon fmt` produce no diff.
- `moon test --target js,native`: js 87/87, native 82/82.
- Live socket-level re-run of the original issue reproduction table: all rows pass (index serving, MIME/ETag/Content-Length, unrelated & short routes, traversal confinement, 405, 304).
- `moon publish` validation passed (packaged zip extracted + `moon check` green, server 200 OK) — oboard/mocket@0.9.0 is on mooncakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)