### PR TITLE
chore: release v0.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 benchmarks/results/
 benchmarks/nitro/.nitro/
 benchmarks/nitro/.output/
+.claude/

--- a/cookie.mbt
+++ b/cookie.mbt
@@ -28,9 +28,8 @@ pub fn HttpRequest::get_cookie(
   self : HttpRequest,
   name : String,
 ) -> CookieItem? {
+  // 请求头现在大小写不敏感，`Cookie` 一次查找即可。
   if self.headers.get("Cookie") is Some(cookie) {
-    parse_cookie(cookie).get(name)
-  } else if self.headers.get("cookie") is Some(cookie) {
     parse_cookie(cookie).get(name)
   } else {
     None

--- a/examples/route/main.mbt
+++ b/examples/route/main.mbt
@@ -34,7 +34,7 @@ async fn main {
   })
 
   // Async Response
-  ..get("/async_data", fn(_event) noraise {
+  ..get("/async_data", _event => {
     ({ "name": "John Doe", "age": 30, "city": "New York" } : Json)
   })
 

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "oboard/mocket"
 
-version = "0.9.0"
+version = "0.9.1"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -38,6 +38,8 @@ pub fn parse_form_data(BytesView) -> Map[String, String]
 
 pub fn parse_multipart(BytesView, String) -> Map[String, MultipartFormValue]
 
+pub fn parse_query(StringView) -> Map[String, String]
+
 pub fn register_ws_connection(String, (String) -> Unit, (Bytes) -> Unit, () -> Unit) -> Unit
 
 pub fn register_ws_handler(Mocket, Int) -> Unit
@@ -99,6 +101,7 @@ pub(all) struct HttpRequest {
 pub fn[T : BodyReader] HttpRequest::body(Self) -> T raise
 pub fn HttpRequest::get_cookie(Self, String) -> CookieItem?
 pub fn[T : @json.FromJson] HttpRequest::json(Self) -> T raise
+pub fn HttpRequest::query(Self) -> Map[String, String]
 pub impl Responder for HttpRequest
 
 pub(all) struct HttpResponse {

--- a/request.mbt
+++ b/request.mbt
@@ -28,6 +28,13 @@ pub fn[T : FromJson] HttpRequest::json(self : HttpRequest) -> T raise {
 }
 
 ///|
+// 返回 URL 解码后的查询参数键值对。例如 `GET /search?q=moon&page=2`
+// 得到 `{ "q": "moon", "page": "2" }`。
+pub fn HttpRequest::query(self : HttpRequest) -> Map[String, String] {
+  parse_query(self.query)
+}
+
+///|
 pub impl BodyReader for String with fn from_request(req : HttpRequest) -> String raise {
   let bytes = req.raw_body
   let arr = bytes.to_array()
@@ -86,4 +93,27 @@ test "read_body" {
     ),
   )
   json_inspect(json, content={ "Hello": "World!" })
+}
+
+///|
+test "query_parsing" {
+  let req = HttpRequest::{
+    http_method: "GET",
+    url: "/search",
+    query: "q=moon&page=2&tag=hello+world",
+    headers: Map([]),
+    raw_body: b"",
+  }
+  let map = req.query()
+  @test.assert_eq(map.get("q").unwrap_or(""), "moon")
+  @test.assert_eq(map.get("page").unwrap_or(""), "2")
+  @test.assert_eq(map.get("tag").unwrap_or(""), "hello world")
+  let empty = HttpRequest::{
+    http_method: "GET",
+    url: "/plain",
+    query: "",
+    headers: Map([]),
+    raw_body: b"",
+  }
+  @test.assert_eq(empty.query().length(), 0)
 }

--- a/request_conformance.mbt
+++ b/request_conformance.mbt
@@ -52,6 +52,23 @@ async test "route with no query string yields an empty query" {
 }
 
 ///|
+async test "query parameters are URL-decoded and exposed via HttpRequest::query" {
+  let app = new()
+  let captured : Array[String] = []
+  app.get("/search", event => {
+    let q = event.req.query()
+    captured.push(q.get("q").unwrap_or(""))
+    captured.push(q.get("page").unwrap_or(""))
+    captured.push(q.get("tag").unwrap_or(""))
+    "ok"
+  })
+  ignore(
+    dispatch_http(app, "GET", "/search?q=moon&page=2&tag=hello+world", {}, b""),
+  )
+  @test.assert_eq(captured, ["moon", "2", "hello world"])
+}
+
+///|
 async test "PUT and PATCH bodies are delivered to the handler" {
   let app = new()
   let captured : Array[String] = []

--- a/static.mbt
+++ b/static.mbt
@@ -139,7 +139,6 @@ pub fn Mocket::static_assets(
       ),
     )
     // Parse Accept-Encoding
-    // Headers are Map[StringView, StringView]
     let accept_encoding = event.req.headers.get("Accept-Encoding").unwrap_or("")
     let encodings = provider.get_encodings()
     let matched_encodings = []

--- a/utils.mbt
+++ b/utils.mbt
@@ -73,6 +73,30 @@ pub fn parse_form_data(bytes : BytesView) -> Map[String, String] {
 }
 
 ///|
+// 解析 URL 查询字符串（不含 `?`）成键值对，键值会做 URL 解码。
+// 与 parse_form_data 共享相同的 `&`/`=` 分割逻辑。
+pub fn parse_query(query_string : StringView) -> Map[String, String] {
+  let res = Map([])
+  if query_string.length() == 0 {
+    return res
+  }
+  // Split by '&'
+  let mut start = 0
+  let len = query_string.length()
+  for i in 0..<len {
+    if query_string[i] == '&' {
+      let part = query_string[start:i]
+      parse_kv(@utf8.encode(part)[:], res)
+      start = i + 1
+    }
+  }
+  if start < len {
+    parse_kv(@utf8.encode(query_string[start:len])[:], res)
+  }
+  res
+}
+
+///|
 fn parse_kv(part : BytesView, map : Map[String, String]) -> Unit {
   let len = part.length()
   let mut eq_idx = -1


### PR DESCRIPTION
## 0.9.1

Adds query parsing and cleans up leftover API remnants from the unified
request contract.

### Changes
- **feat**: `HttpRequest::query()` — returns URL-decoded query parameters as `Map[String, String]`, so handlers can write `event.req.query().get("q")` the same way they use `event.params.get("id")` for path params. Adds the shared `parse_query` helper (reuses `parse_kv`; handles `&`/`=` splits, URL decoding, and `+` → space).
- **fix**: `HttpRequest::get_cookie` now uses a single case-insensitive `Cookie` header lookup (the previous dual `Cookie`/`cookie` check was a leftover from the case-sensitive headers era).
- **chore**: remove the stale `noraise` annotation in `examples/route` and an obsolete header-type comment in `static.mbt`; add `.claude/` to `.gitignore`.
- **chore**: regenerate `pkg.generated.mbti` for the new public symbols.

### Verification
- `moon check --deny-warn` ✅
- `moon info --target native` (mbti regenerated, diff committed) ✅
- `moon fmt` clean ✅
- `moon test --target js,native` → js 105/105, native 100/100 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)