### PR TITLE
fix: replace moonbitlang/core/strconv with core/string

### DIFF
--- a/benchmarks/mocket/main.mbt
+++ b/benchmarks/mocket/main.mbt
@@ -35,7 +35,7 @@ async fn main {
 fn benchmark_port() -> Int {
   match @env.get_env_var("PORT") {
     Some(port_text) => {
-      let port : Int = @strconv.from_str(port_text) catch { _ => 3000 }
+      let port : Int = @string.from_str(port_text) catch { _ => 3000 }
       port
     }
     None => 3000

--- a/benchmarks/mocket/moon.pkg
+++ b/benchmarks/mocket/moon.pkg
@@ -2,7 +2,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/core/env",
   "moonbitlang/core/json",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "oboard/mocket" @mocket_lib,
 }
 

--- a/benchmarks/mocket_middleware/main.mbt
+++ b/benchmarks/mocket_middleware/main.mbt
@@ -51,7 +51,7 @@ fn noop_middleware() -> @mocket_lib.Middleware {
 fn benchmark_port() -> Int {
   match @env.get_env_var("PORT") {
     Some(port_text) => {
-      let port : Int = @strconv.from_str(port_text) catch { _ => 3000 }
+      let port : Int = @string.from_str(port_text) catch { _ => 3000 }
       port
     }
     None => 3000

--- a/benchmarks/mocket_middleware/moon.pkg
+++ b/benchmarks/mocket_middleware/moon.pkg
@@ -2,7 +2,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/core/env",
   "moonbitlang/core/json",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "oboard/mocket" @mocket_lib,
 }
 

--- a/examples/route/main.mbt
+++ b/examples/route/main.mbt
@@ -76,7 +76,7 @@ async fn main {
 fn example_port() -> Int {
   match @env.get_env_var("MOCKET_PORT") {
     Some(port_text) => {
-      let port : Int = @strconv.from_str(port_text) catch { _ => 4000 }
+      let port : Int = @string.from_str(port_text) catch { _ => 4000 }
       port
     }
     None => 4000

--- a/examples/route/moon.pkg
+++ b/examples/route/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "moonbitlang/async",
   "moonbitlang/core/env",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "oboard/mocket",
   "oboard/mocket/cors",
 }

--- a/moon.pkg
+++ b/moon.pkg
@@ -13,7 +13,6 @@ import {
   "moonbitlang/async/websocket",
   "moonbitlang/core/bench",
   "moonbitlang/core/json",
-  "moonbitlang/core/strconv",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbitlang/core/buffer",


### PR DESCRIPTION
`moonbitlang/core` 0.10.12 removed `moonbitlang/core/strconv` — only `core/internal/strconv` remains. Any module depending on mocket now fails package solving before a single file is compiled:

```
Error: Failed to calculate build plan
Caused by:
    0: Failed to solve package relationship
    1: Cannot find import 'moonbitlang/core/strconv' in oboard/mocket@0.9.1
```

I hit this from downstream — an example in [rabbita](https://github.com/moonbit-community/rabbita) that depends on mocket stopped resolving on the nightly toolchain.

`core/string` carries the same API on both 0.10.11 and 0.10.12, so this builds on current stable *and* nightly.

## Changes

- **`moon.pkg`** (root) imported `core/strconv`, but nothing in the package references `@strconv` — the import was dead. The package already imports `core/string`, so this is just a deletion.
- **`benchmarks/mocket`, `benchmarks/mocket_middleware`, `examples/route`** each parse a port. They switch to `@string.from_str`, which is the same `FromStr` trait method exposed as a free function (`#as_free_fn`), so the call sites keep their inferred-type form:

```diff
-      let port : Int = @strconv.from_str(port_text) catch { _ => 3000 }
+      let port : Int = @string.from_str(port_text) catch { _ => 3000 }
```

7 files, +6/−7.

## Verification

| toolchain | state | `moon check --target native` |
|---|---|---|
| nightly `v0.10.11+9de356786-nightly` | `main` | **exit 255** — `Cannot find import 'moonbitlang/core/strconv'` |
| nightly `v0.10.11+9de356786-nightly` | this branch | **exit 0** |
| stable `v0.10.11+6ff76a5f9` | this branch | **exit 0** (js and native) |

`moon test --target js,native` on this branch: **105 passed** (js), **100 passed** (native).

## Heads-up, unrelated to this PR

While running your CI steps locally on the current stable toolchain (`moon 0.1.20260827` / `moonc v0.10.11+6ff76a5f9`), two of them fail on **`main` itself**, with this branch stashed:

1. `moon check --deny-warn` — exit 255:
   ```
   internal/header/header.mbt:41:13
     let buf = StringBuilder::new()
     Warning (deprecated): Use `StringBuilder()` instead
   ```
2. `moon fmt` + `git diff --exit-code` — the formatter rewrites a number of files (`content_type.mbt`, `cookie.mbt`, `dispatch.mbt`, `middleware.mbt`, `mocket.js.mbt`, …).

Your last green run was 2026-08-22, so I think the toolchain has moved since. I deliberately left both alone to keep this PR reviewable rather than burying a 7-line fix under unrelated reformatting — happy to send either as a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmoyPMELemz5hdNNdXyAkm